### PR TITLE
feat(ci): add end-to-end test with Cypress

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -1,0 +1,31 @@
+name: End-to-End Test
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Start application
+      run: npm start &
+
+    - name: Wait for application to start
+      run: sleep 30
+
+    - name: Run Cypress end-to-end tests
+      run: npm run cypress:run:e2e


### PR DESCRIPTION
- Added GitHub Actions workflow for end-to-end testing
- Workflow triggers on push to main branch
- Uses Ubuntu latest as the runner
- Installs Node.js version 14
- Installs project dependencies using npm
- Starts the application before running tests
- Waits for 30 seconds to ensure the application is fully started
- Runs Cypress end-to-end tests